### PR TITLE
renovate のグループ化を無効にする

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["config:recommended", "group:allNonMajor"],
+  "extends": ["config:recommended"],
   "rangeStrategy": "bump",
   "reviewers": ["watagit"],
   "packageRules": [


### PR DESCRIPTION
現在の renovate の設定ではマイナーバージョンのアップデートがあるライブラリをまとめて PR を作成している。
#218 で minimumReleaseAge が設定されたことで PR 内のいずれかのライブラリが引っかかった場合 CI が落ちる。
PR 作成からマージまで時間がかかることが多くなったためグルーピングを無効にする。

https://github.com/watagit/portfolio/pull/222