### PR TITLE
fix: renovate-auto-assign のトリガーイベントを push に修正

### DIFF
--- a/.github/workflows/renovate-auto-assign.yml
+++ b/.github/workflows/renovate-auto-assign.yml
@@ -9,7 +9,7 @@ jobs:
   assign-reviewer:
     if: >
       github.event.workflow_run.conclusion == 'success' &&
-      github.event.workflow_run.event == 'pull_request'
+      github.event.workflow_run.event == 'push'
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write


### PR DESCRIPTION
## 概要

- `renovate-auto-assign.yml` の `if` 条件で `workflow_run.event == 'pull_request'` としていたが、`Check source codes` ワークフローは `push` イベントで動作するため常にスキップされていた
- 条件を `push` に変更し、Renovate PR へのレビュワーアサインが正しく動作するよう修正

## テスト計画

- [ ] 次の Renovate PR 作成時に `Renovate PR にレビュワーをアサイン` ワークフローが `skipped` にならず実行されることを確認
- [ ] `watagit` がレビュワーとしてアサインされることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)